### PR TITLE
feat: persist Todo list & theme using electron-store

### DIFF
--- a/src/main/persistence/store.ts
+++ b/src/main/persistence/store.ts
@@ -1,0 +1,37 @@
+import type { Todo } from "../../shared/trpc.js";
+import { type Theme } from "../../shared/trpc.js";
+
+/** Persistence schema */
+type StoreSchema = {
+  todos: Todo[];
+  theme: Theme;
+};
+
+/** Declare only the minimum API needed on the instance side */
+interface Store {
+  get<K extends keyof StoreSchema>(key: K): StoreSchema[K];
+  set<K extends keyof StoreSchema>(key: K, value: StoreSchema[K]): void;
+}
+
+/** Singleton */
+let instance: Store | undefined;
+
+/**
+ * Returns the shared Store instance.
+ * Dynamically imports ESM-only electron-store at runtime.
+ */
+export async function getStore(): Promise<Store> {
+  if (instance) return instance;
+
+  // Get constructor via dynamic import
+  const { default: StoreCtor } = await import("electron-store");
+
+  // Instantiate and cast to type that guarantees only required methods
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  instance = new (StoreCtor as any)({
+    name: "settings",
+    defaults: { todos: [], theme: "system" },
+  }) as Store;
+
+  return instance;
+}

--- a/src/main/repository/theme-repository.ts
+++ b/src/main/repository/theme-repository.ts
@@ -1,0 +1,19 @@
+import { getStore } from "../persistence/store.js";
+
+/**
+ * Repository for persisting UI theme preference.
+ * Values: 'light' | 'dark' | 'system'
+ */
+export const ThemeRepo = {
+  async get(): Promise<"light" | "dark" | "system"> {
+    return (await getStore()).get("theme");
+  },
+
+  async set(
+    value: "light" | "dark" | "system",
+  ): Promise<"light" | "dark" | "system"> {
+    const store = await getStore();
+    store.set("theme", value);
+    return value;
+  },
+};

--- a/src/main/repository/todo-repository.ts
+++ b/src/main/repository/todo-repository.ts
@@ -1,0 +1,48 @@
+import type { Todo } from "../../shared/trpc.js";
+import { getStore } from "../persistence/store.js";
+
+/**
+ * Repository layer for Todo entities.
+ * Provides CRUD operations backed by electron‑store (v10).
+ */
+export const TodoRepo = {
+  /**
+   * Get all todos.
+   */
+  async findAll(): Promise<Todo[]> {
+    return (await getStore()).get("todos");
+  },
+
+  /**
+   * Append a new todo and return the updated list.
+   */
+  async add(todo: Todo): Promise<Todo[]> {
+    const store = await getStore();
+    const todos = store.get("todos");
+    store.set("todos", [...todos, todo]);
+    return store.get("todos");
+  },
+
+  /**
+   * Remove a todo by id and return the updated list.
+   */
+  async remove(id: string): Promise<Todo[]> {
+    const store = await getStore();
+    const next = (store.get("todos") as Todo[]).filter((t) => t.id !== id);
+    store.set("todos", next);
+    return next;
+  },
+
+  /**
+   * Toggle the `completed` flag of a todo by id.
+   * Expects each Todo to have a boolean `completed` property.
+   */
+  async toggle(id: string): Promise<Todo[]> {
+    const store = await getStore();
+    const next = (store.get("todos") as Todo[]).map((t) =>
+      t.id === id ? { ...t, completed: !t.completed } : t,
+    );
+    store.set("todos", next);
+    return next;
+  },
+};

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -6,7 +6,7 @@ import "./assets/main.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+    <ThemeProvider>
       <App />
     </ThemeProvider>
   </StrictMode>,

--- a/src/shared/trpc.ts
+++ b/src/shared/trpc.ts
@@ -1,8 +1,14 @@
 import { initTRPC } from "@trpc/server";
 import { z } from "zod";
+import { ThemeRepo } from "../main/repository/theme-repository.js";
+import { TodoRepo } from "../main/repository/todo-repository.js";
 
 const t = initTRPC.create();
 export const publicProcedure = t.procedure;
+
+export const ThemeSchema = z.enum(["light", "dark", "system"]);
+export type Theme = z.infer<typeof ThemeSchema>;
+export const DefaultTheme: Theme = "system";
 
 export const TodoSchema = z.object({
   id: z.string(),
@@ -11,46 +17,44 @@ export const TodoSchema = z.object({
 });
 export type Todo = z.infer<typeof TodoSchema>;
 
-// In-memory store (per Main process instance)
-const todos: Todo[] = [];
-
 export const appRouter = t.router({
   ping: publicProcedure.query(() => {
     console.log("[main] pong");
     return "pong";
   }),
   task: t.router({
-    list: publicProcedure.query(() => todos),
+    list: publicProcedure.query(async () => {
+      return await TodoRepo.findAll();
+    }),
     add: publicProcedure
       .input(z.object({ title: z.string().min(1, "title required") }))
-      .mutation(({ input }) => {
+      .mutation(async ({ input }) => {
         const newTodo: Todo = {
           id: crypto.randomUUID(),
           title: input.title,
           completed: false,
         };
-        todos.push(newTodo);
-        return newTodo;
+        return await TodoRepo.add(newTodo); // returns updated list
       }),
     toggle: publicProcedure
-      .input(z.object({ id: z.string(), completed: z.boolean() }))
-      .mutation(({ input }) => {
-        const todo = todos.find((t) => t.id === input.id);
-        if (!todo) {
-          throw new Error("Todo not found");
-        }
-        todo.completed = input.completed;
-        return todo;
+      .input(z.object({ id: z.string() }))
+      .mutation(async ({ input }) => {
+        return await TodoRepo.toggle(input.id); // updated list
       }),
     remove: publicProcedure
       .input(z.object({ id: z.string() }))
-      .mutation(({ input }) => {
-        const index = todos.findIndex((t) => t.id === input.id);
-        if (index === -1) {
-          throw new Error("Todo not found");
-        }
-        const [removed] = todos.splice(index, 1);
-        return removed;
+      .mutation(async ({ input }) => {
+        return await TodoRepo.remove(input.id); // updated list
+      }),
+  }),
+  theme: t.router({
+    get: publicProcedure.query(async () => {
+      return await ThemeRepo.get();
+    }),
+    set: publicProcedure
+      .input(z.enum(["light", "dark", "system"]))
+      .mutation(async ({ input }) => {
+        return await ThemeRepo.set(input);
       }),
   }),
 });


### PR DESCRIPTION
* Add lazy-loaded `electron-store` wrapper (`store.ts`) with dynamic ESM import
* Introduce repository layer:
  * `TodoRepository` – CRUD backed by electron-store
  * `ThemeRepository` – get/set theme preference
* Refactor tRPC router to delegate to repositories
* Replace localStorage-based theme handling with custom `ThemeProvider` that syncs theme via tRPC and persists single-source-of-truth in Main
* Remove next-themes persistence; keep in-memory only
* Handle type-checking quirks for electron-store
* Guard against multiple Electron instances