### PR TITLE
chore(deps): add dependencies label to renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
Configured Renovate to automatically add "dependencies" label to all dependency update pull requests for better organization and filtering.